### PR TITLE
Updated component requirements and allow sensor choice

### DIFF
--- a/homeassistant/components/heatmiser/climate.py
+++ b/homeassistant/components/heatmiser/climate.py
@@ -24,10 +24,6 @@ CONF_IPADDRESS = 'ipaddress'
 CONF_PORT = 'port'
 CONF_TSTATS = 'tstats'
 
-DOMAIN = 'heatmiser_uh1'
-ATTR_NAME = 'name'
-DEFAULT_NAME = 'uh1'
-
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the heatmiser thermostat."""
     from heatmiserV3 import heatmiser, connection
@@ -153,7 +149,7 @@ class HeatmiserV3Thermostat(ClimateDevice):
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
-        _LOGGER.info("Setting temperature to {}".format(int(temperature)))
+        """_LOGGER.info("Setting temperature to {}".format(int(temperature)))"""
         if temperature is None or self.dcb == None:
             return
         if self.heating == 0:
@@ -179,4 +175,4 @@ class HeatmiserV3Thermostat(ClimateDevice):
             self._max_temp = 17
             self._mode = STATE_HEAT if self._current_temperature < self._target_temperature else STATE_OFF
             
-        _LOGGER.info("Target temperature for {} is {}".format(self._name, self._target_temperature))
+       """ _LOGGER.info("Target temperature for {} is {}".format(self._name, self._target_temperature))"""

--- a/homeassistant/components/heatmiser/climate.py
+++ b/homeassistant/components/heatmiser/climate.py
@@ -149,7 +149,6 @@ class HeatmiserV3Thermostat(ClimateDevice):
     def set_temperature(self, **kwargs):
         """Set new target temperature."""
         temperature = kwargs.get(ATTR_TEMPERATURE)
-        """_LOGGER.info("Setting temperature to {}".format(int(temperature)))"""
         if temperature is None or self.dcb == None:
             return
         if self.heating == 0:
@@ -175,4 +174,3 @@ class HeatmiserV3Thermostat(ClimateDevice):
             self._max_temp = 17
             self._mode = STATE_HEAT if self._current_temperature < self._target_temperature else STATE_OFF
             
-       """ _LOGGER.info("Target temperature for {} is {}".format(self._name, self._target_temperature))"""


### PR DESCRIPTION
## Description:

- fixed requirement using latest heatmiserV3 
- sensor choice between floor and air
- can now turn thermostat to frost mode and alter min max temp
- fixed precision now whole degrees
- improved polling by force first thermostat in list to call connection

**Related issue (if applicable):** fixes #13146

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

climate:
  - platform: heatmiser
    ipaddress: 192.168.1.87
    port: 26
    tstats:
      - room: Living Room
        id: 1
        model: prt
        sensor: air
```

## Checklist:
  - [X] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard/__init__.py#L23
